### PR TITLE
Page Forms Now Have Full Screen Support

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,10 @@ page_forms:
 	  {% for item in page.page_forms %}
 		 {% assign my_counter = my_counter | plus: 1 %}
          <div class="panel panel-{{ item.color }}">
-            <div class="panel-heading" id="ptext{{ my_counter }}" onclick="openFullscreen(this);"><i class="fa fa-2x">{{ item.label }}</i></div>
+            <div class="panel-heading" id="ptext{{ my_counter }}">
+		  <div><i class="fa fa-2x">{{ item.label }}</i></div>
+		  <div class="expand-icon" onclick="openFullscreen(this);" style="float: right;"></div>
+	    </div>
             <div class="panel-body">
                   <div class="col-sm-4 has-feedback" style="padding-bottom: 20px;">
                      <label for="pname" class="col-lg-12"><span class="fa fa-pencil"></span></label>

--- a/index.html
+++ b/index.html
@@ -148,14 +148,14 @@ page_forms:
          <div class="panel panel-{{ item.color }}">
             <div class="panel-heading" id="ptext{{ my_counter }}">
 		  <span><i class="fa fa-2x">{{ item.label }}</i></span>
-		  <span class="expand-icon" onclick="openFullscreen(this);" style="float: right;"></span>
+		  <span class="expand-icon" onclick="openFullscreen(this);" style="float: right;cursor: pointer;"></span>
 	    </div>
             <div class="panel-body">
                   <div class="col-sm-4 has-feedback" style="padding-bottom: 20px;">
                      <label for="pname" class="col-lg-12"><span class="fa fa-pencil"></span></label>
                      <div class="col-lg-12">
 		        <div class="input-group">
-		            <span class="input-group-addon" id="picon{{ my_counter }}"></span>
+		            <span class="input-group-addon" id="picon{{ my_counter }}" style="cursor: pointer;"></span>
 		            <input type="text" class="form-control" id="pname{{ my_counter }}" placeholder="Enter Page Name" 
                             list="pnames" oninput="em_txt(this)" accesskey="{{ my_counter }}">
 		        </div>

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ page_forms:
 	  {% for item in page.page_forms %}
 		 {% assign my_counter = my_counter | plus: 1 %}
          <div class="panel panel-{{ item.color }}">
-            <div class="panel-heading" id="ptext{{ my_counter }}" onclick="openFullscreen();"><i class="fa fa-2x">{{ item.label }}</i></div>
+            <div class="panel-heading" id="ptext{{ my_counter }}" onclick="openFullscreen(this);"><i class="fa fa-2x">{{ item.label }}</i></div>
             <div class="panel-body">
                   <div class="col-sm-4 has-feedback" style="padding-bottom: 20px;">
                      <label for="pname" class="col-lg-12"><span class="fa fa-pencil"></span></label>

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ page_forms:
 	  {% for item in page.page_forms %}
 		 {% assign my_counter = my_counter | plus: 1 %}
          <div class="panel panel-{{ item.color }}">
-            <div class="panel-heading" id="ptext{{ my_counter }}"><i class="fa fa-2x">{{ item.label }}</i></div>
+            <div class="panel-heading" id="ptext{{ my_counter }}" onclick="openFullscreen();"><i class="fa fa-2x">{{ item.label }}</i></div>
             <div class="panel-body">
                   <div class="col-sm-4 has-feedback" style="padding-bottom: 20px;">
                      <label for="pname" class="col-lg-12"><span class="fa fa-pencil"></span></label>

--- a/index.html
+++ b/index.html
@@ -147,8 +147,8 @@ page_forms:
 		 {% assign my_counter = my_counter | plus: 1 %}
          <div class="panel panel-{{ item.color }}">
             <div class="panel-heading" id="ptext{{ my_counter }}">
-		  <div><i class="fa fa-2x">{{ item.label }}</i></div>
-		  <div class="expand-icon" onclick="openFullscreen(this);" style="float: right;"></div>
+		  <span><i class="fa fa-2x">{{ item.label }}</i></span>
+		  <span class="expand-icon" onclick="openFullscreen(this);" style="float: right;"></span>
 	    </div>
             <div class="panel-body">
                   <div class="col-sm-4 has-feedback" style="padding-bottom: 20px;">

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ page_forms:
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">Options
         <span class="caret"></span></a>
         <ul class="dropdown-menu">
-          <li><a href="javascript:void(0)" id="opnmi"">Open Website</a></li>
+          <li><a href="javascript:void(0)" id="opnmi">Open Website</a></li>
           <li><a href="javascript:void(0)" id="submi">Submit Website</a></li>
           <li><a href="javascript:void(0)" id="optmi">Website Options</a></li>
         </ul>

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -290,10 +290,7 @@ function resizeHtmlEditor() {
     } else {
 	    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
 	    $('div.jHtmlArea').css('width', '100%');
-	    //if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
-	    if(screen.width < 400) {
-	       $('div.jHtmlArea textarea').css('height', '300px');
-	    } else $('div.jHtmlArea textarea').css('height', '100%');
+	    $('div.jHtmlArea textarea').css('height', 'auto');
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -282,7 +282,10 @@ function resizeHtmlEditor() {
 	    //if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
 	    if(screen.width < 400) {
 	       $('div.jHtmlArea textarea').css('height', '300px');
-	    } else $('div.jHtmlArea textarea').css('height', '200px');
+	       $('expand-icon').html("");
+	    } else {
+	       $('div.jHtmlArea textarea').css('height', '200px');
+	       $('expand-icon').html("<a href='#'><i class='fa fa-arrows-alt fa-2x'></i></a>");
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());
@@ -291,6 +294,7 @@ function resizeHtmlEditor() {
 	    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
 	    $('div.jHtmlArea').css('width', '100%');
 	    $('div.jHtmlArea textarea').css('height', window.innerHeight - 221);
+	    $('expand-icon').html("");
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());
@@ -473,7 +477,7 @@ function esc_code(cd) {
 }
 
 function openFullscreen(th) {
-  var elem = th.parentElement;
+  var elem = th.parentElement.parentElement;
   if (elem.requestFullscreen) {
     elem.requestFullscreen();
   } else if (elem.mozRequestFullScreen) { /* Firefox */

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -473,6 +473,7 @@ function openFullscreen(th) {
   } else if (elem.msRequestFullscreen) { /* IE/Edge */
     elem.msRequestFullscreen();
   }
+  $('div.jHtmlArea textarea').css('height', '100%');
 }
 
  function readCSSFile(evt) {

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -462,6 +462,19 @@ function esc_code(cd) {
     return ch;
 }
 
+function openFullscreen() {
+  var elem = document.getElementById("ptext1");
+  if (elem.requestFullscreen) {
+    elem.requestFullscreen();
+  } else if (elem.mozRequestFullScreen) { /* Firefox */
+    elem.mozRequestFullScreen();
+  } else if (elem.webkitRequestFullscreen) { /* Chrome, Safari & Opera */
+    elem.webkitRequestFullscreen();
+  } else if (elem.msRequestFullscreen) { /* IE/Edge */
+    elem.msRequestFullscreen();
+  }
+}
+
  function readCSSFile(evt) {
     //Retrieve the first (and only!) File from the FileList object
    var f = evt.target.files[0]; 

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -293,7 +293,7 @@ function resizeHtmlEditor() {
 	    //if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
 	    if(screen.width < 400) {
 	       $('div.jHtmlArea textarea').css('height', '300px');
-	    } else $('div.jHtmlArea textarea').css('height', '500px');
+	    } else $('div.jHtmlArea textarea').css('height', '100%');
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -276,16 +276,18 @@
         });
 
 function resizeHtmlEditor() {
-    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
-    $('div.jHtmlArea').css('width', '100%');
-    //if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
-    if(screen.width < 400) {
-       $('div.jHtmlArea textarea').css('height', '300px');
-    } else $('div.jHtmlArea textarea').css('height', '200px');
-    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
-    // $('div.jHtmlArea iframe').css('width', '100%');
-    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());
-    $('div.jHtmlArea iframe').height($('div.jHtmlArea').height() - $('div.ToolBar').height() - 6);
+    if (!document.fullscreenElement) {
+	    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
+	    $('div.jHtmlArea').css('width', '100%');
+	    //if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+	    if(screen.width < 400) {
+	       $('div.jHtmlArea textarea').css('height', '300px');
+	    } else $('div.jHtmlArea textarea').css('height', '200px');
+	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
+	    // $('div.jHtmlArea iframe').css('width', '100%');
+	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());
+	    $('div.jHtmlArea iframe').height($('div.jHtmlArea').height() - $('div.ToolBar').height() - 6);
+    }
 }
 
 function css_update_ta() {

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -285,7 +285,7 @@ function resizeHtmlEditor() {
 	       $('.expand-icon').html("");
 	    } else {
 	       $('div.jHtmlArea textarea').css('height', '200px');
-	       $('.expand-icon').html("<a href='#'><i class='fa fa-arrows-alt fa-2x'></i></a>");
+	       $('.expand-icon').html("<i class='fa fa-arrows-alt fa-2x'></i>");
 	    }
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -286,6 +286,7 @@ function resizeHtmlEditor() {
 	    } else {
 	       $('div.jHtmlArea textarea').css('height', '200px');
 	       $('expand-icon').html("<a href='#'><i class='fa fa-arrows-alt fa-2x'></i></a>");
+	    }
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -282,10 +282,10 @@ function resizeHtmlEditor() {
 	    //if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
 	    if(screen.width < 400) {
 	       $('div.jHtmlArea textarea').css('height', '300px');
-	       $('expand-icon').html("");
+	       $('.expand-icon').html("");
 	    } else {
 	       $('div.jHtmlArea textarea').css('height', '200px');
-	       $('expand-icon').html("<a href='#'><i class='fa fa-arrows-alt fa-2x'></i></a>");
+	       $('.expand-icon').html("<a href='#'><i class='fa fa-arrows-alt fa-2x'></i></a>");
 	    }
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
@@ -295,7 +295,7 @@ function resizeHtmlEditor() {
 	    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
 	    $('div.jHtmlArea').css('width', '100%');
 	    $('div.jHtmlArea textarea').css('height', window.innerHeight - 221);
-	    $('expand-icon').html("");
+	    $('.expand-icon').html("");
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -462,8 +462,8 @@ function esc_code(cd) {
     return ch;
 }
 
-function openFullscreen(elem) {
-  //var elem = document.getElementById("ptext1");
+function openFullscreen(th) {
+  var elem = th.parentElement;
   if (elem.requestFullscreen) {
     elem.requestFullscreen();
   } else if (elem.mozRequestFullScreen) { /* Firefox */

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -287,6 +287,17 @@ function resizeHtmlEditor() {
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());
 	    $('div.jHtmlArea iframe').height($('div.jHtmlArea').height() - $('div.ToolBar').height() - 6);
+    } else {
+	    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
+	    $('div.jHtmlArea').css('width', '100%');
+	    //if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+	    if(screen.width < 400) {
+	       $('div.jHtmlArea textarea').css('height', '300px');
+	    } else $('div.jHtmlArea textarea').css('height', '500px');
+	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
+	    // $('div.jHtmlArea iframe').css('width', '100%');
+	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());
+	    $('div.jHtmlArea iframe').height($('div.jHtmlArea').height() - $('div.ToolBar').height() - 6);
     }
 }
 
@@ -475,7 +486,7 @@ function openFullscreen(th) {
   } else if (elem.msRequestFullscreen) { /* IE/Edge */
     elem.msRequestFullscreen();
   }
-  $('div.jHtmlArea textarea').css('height', window.innerHeight - 44);
+  //$('div.jHtmlArea textarea').css('height', window.innerHeight - 44);
 }
 
  function readCSSFile(evt) {

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -473,7 +473,7 @@ function openFullscreen(th) {
   } else if (elem.msRequestFullscreen) { /* IE/Edge */
     elem.msRequestFullscreen();
   }
-  $('div.jHtmlArea textarea').css('height', '100%');
+  $('div.jHtmlArea textarea').css('height', window.innerHeight - 44);
 }
 
  function readCSSFile(evt) {

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -290,7 +290,7 @@ function resizeHtmlEditor() {
     } else {
 	    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
 	    $('div.jHtmlArea').css('width', '100%');
-	    $('div.jHtmlArea textarea').css('height', $('body').height() - 221);
+	    $('div.jHtmlArea textarea').css('height', window.innerHeight - 221);
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -290,7 +290,7 @@ function resizeHtmlEditor() {
     } else {
 	    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
 	    $('div.jHtmlArea').css('width', '100%');
-	    $('div.jHtmlArea textarea').css('height', 'auto');
+	    $('div.jHtmlArea textarea').css('height', $('body').height() - 221);
 	    $('div.jHtmlArea').height($('div.jHtmlArea textarea').height() + 44);
 	    // $('div.jHtmlArea iframe').css('width', '100%');
 	    $('div.jHtmlArea iframe').width($('div.jHtmlArea').width());

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -462,8 +462,8 @@ function esc_code(cd) {
     return ch;
 }
 
-function openFullscreen() {
-  var elem = document.getElementById("ptext1");
+function openFullscreen(elem) {
+  //var elem = document.getElementById("ptext1");
   if (elem.requestFullscreen) {
     elem.requestFullscreen();
   } else if (elem.mozRequestFullScreen) { /* Firefox */

--- a/scripts/website_editor.js
+++ b/scripts/website_editor.js
@@ -276,7 +276,12 @@
         });
 
 function resizeHtmlEditor() {
-    if (!document.fullscreenElement) {
+	if (
+	  !(document.fullscreenElement || /* Standard syntax */
+	  document.webkitFullscreenElement || /* Chrome, Safari and Opera syntax */
+	  document.mozFullScreenElement ||/* Firefox syntax */
+	  document.msFullscreenElement) /* IE/Edge syntax */
+	) {
 	    $('div.jHtmlArea').find('div.ToolBar').css('width', '100%');
 	    $('div.jHtmlArea').css('width', '100%');
 	    //if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {


### PR DESCRIPTION
Page forms now have full screen support.  Users can now click on expand icon in the header of a page form to see it in full screen.
